### PR TITLE
add a missing return in AlignedArray::operator=

### DIFF
--- a/src/base/AlignedArray.h
+++ b/src/base/AlignedArray.h
@@ -52,6 +52,8 @@ struct AlignedArray
         other.data = 0;
         other.size = 0;
         other.capacity = 0;
+
+        return *this;
     }
 
     T* begin()


### PR DESCRIPTION
https://goo.gl/jeJT26
```
int main() {
  AlignedArray<int> a;
  a = AlignedArray<int>();
}
```
produces
```
.code.tio.cpp:51:5: warning: control reaches end of non-void function [-Wreturn-type]
    }
    ^
.code.tio.cpp:136:5: note: in instantiation of member function 'AlignedArray<int>::operator=' requested here
  a = AlignedArray<int>();
    ^
1 warning generated.
/srv/wrappers/cpp-clang: line 5: 17254 Illegal instruction     (core dumped) ./.bin.tio "$@" < .input.tio
```